### PR TITLE
Visualize 3D Tensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Pillow images can be visualized in RGB and other color modes:
 
 ```python
 from torchvision.datasets import CIFAR10
-dataset = CIFAR10('.', dowload=True)
+dataset = CIFAR10('.', download=True)
 img = dataset[0][0]
 tensorhue.viz(img) ✅
 ```
@@ -120,3 +120,22 @@ tensorhue.viz(conf_matrix, vmin=0, vmax=1, scale=3)
 </div>
 
 The `scale` parameter scales up the 'pixels' of the tensor so that small tensors are easier to view.
+
+## Rendering 3D Tensors
+
+TensorHue also allows rendering 3D Tensors like MRI volumes, GIFs, Videos, or simply batches of images, both automatically and manually. This example stacks a bunch of CIFAR images and renders the resulting volume in a 3x3 grid.
+
+```python
+import torch
+from einops import rearrange
+from torchvision.transforms.functional import pil_to_tensor
+from tensorhue.viz import viz_batch_volume_manual
+batch = [pil_to_tensor(dataset[i][0]) for i in range(261)]
+batch = torch.stack(batch)
+big_batch = rearrange(batch, 'b c h w -> (b c) h w')
+big_batch = rearrange(big_batch, '(b c) h w -> b c h w', b=9)
+viz_batch_volume_manual(big_batch)
+```
+
+You can step through the slices with A+D (or use the left and right arrow keys) and quit the visualization with Q. 
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 numpy
 rich
 matplotlib
+readchar

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,6 +26,7 @@ install_requires =
     numpy
     rich
     matplotlib
+    readchar
 
 [options.packages.find]
 include = tensorhue*

--- a/tensorhue/viz.py
+++ b/tensorhue/viz.py
@@ -1,12 +1,17 @@
 from __future__ import annotations  # backwards type hint compatability for Python 3.7 and 3.8
 import os
 import sys
+import time
+import math
 import warnings
+import readchar
 from rich.console import Console
+from rich.live import Live
 import numpy as np
 from tensorhue.colors import ColorScheme
 from tensorhue._print_opts import PRINT_OPTS
 from tensorhue.converters import tensor_to_numpy, mro_to_strings
+
 
 
 def viz(tensor, **kwargs):
@@ -183,3 +188,216 @@ def get_terminal_size(default_width: int = 100, default_height: int = 70) -> os.
             return os.terminal_size((default_width, default_height))
     else:
         return os.terminal_size((default_width, default_height))
+
+# Visualizing volumetric data (For MRI or videos)
+def viz_volume(tensor, axis=0, pause=0.1, colorscheme: ColorScheme = None, scale=1, legend=True, stride=1, **kwargs):
+    """
+    Visualizes a 3D tensor as an animation through slices.
+
+    Args:
+        tensor (Tensor or ndarray): 3D tensor to visualize (e.g. shape [D, H, W]).
+        axis (int): Axis along which to slice.
+        pause (float): Time to wait between frames in seconds.
+        colorscheme (ColorScheme, optional): Color scheme to use.
+        scale (int): Scaling factor for slice visualization.
+        legend (bool): Show slice index and shape.
+        **kwargs: Passed to color scheme.
+    """
+    np_array = tensor_to_numpy(tensor)
+    
+    if np_array.ndim != 3:
+        raise ValueError("Only 3D tensors can be passed to viz_volume")
+
+    np_array = np.moveaxis(np_array, axis, 0)  # Make slice axis first
+    n_slices = np_array.shape[0]
+    console = Console()
+    with Live(console=console, refresh_per_second=1 / pause, screen=False) as live:
+        for i in range(0, n_slices, stride):
+            slice_2d = np_array[i]
+            scaled = np.repeat(np.repeat(slice_2d, scale, axis=1), scale, axis=0)
+            lines = _viz_2d(scaled, colorscheme, **kwargs)
+            if legend:
+               lines.append(f"[italic]slice = {i}/{n_slices - 1}, shape = {slice_2d.shape}[/]")
+               # lines.append(f"[italic]shape = {shape}[/]")
+            live.update("\n".join(lines))
+            time.sleep(pause)
+
+
+def viz_volume_manual(tensor, axis=0, colorscheme: ColorScheme = None, scale=1, legend=True, stride=1, **kwargs):
+    """
+    Interactive 3D tensor viewer using keyboard input.
+
+    Keys:
+    [a] ← : previous slice
+    [d] → : next slice
+    [q]   : quit
+    """
+    np_array = tensor_to_numpy(tensor)
+
+    if np_array.ndim != 3:
+        raise ValueError("Only 3D tensors can be passed to viz_volume_manual")
+
+    np_array = np.moveaxis(np_array, axis, 0)
+    n_slices = np_array.shape[0]
+    idx = 0
+
+    console = Console()
+
+    def get_render(idx):
+        slice_2d = np_array[idx]
+        scaled = np.repeat(np.repeat(slice_2d, scale, axis=1), scale, axis=0)
+        lines = _viz_2d(scaled, colorscheme, **kwargs)
+        if legend:
+            lines.append(f"[italic]slice = {idx}/{n_slices - 1}, shape = {slice_2d.shape}[/]")
+            lines.append("\u25C4 a |q quit| d \u25BA")
+        return "\n".join(lines)
+
+    with Live(get_render(idx), console=console, screen=False, auto_refresh=False) as live:
+        while True:
+            key = readchar.readkey()
+            new_idx = idx
+            if key == "q":
+                break
+            elif key in ("d", readchar.key.RIGHT):
+                new_idx = (idx + stride) % n_slices
+            elif key in ("a", readchar.key.LEFT):
+                new_idx = (idx - stride) % n_slices
+            if new_idx != idx:
+                idx = new_idx
+                live.update(get_render(idx), refresh=True)
+
+
+def viz_batch_volume(tensor, axis=0, pause=0.1, colorscheme: ColorScheme = None, scale=1, legend=True, stride=1, **kwargs):
+    """
+    Animated viewer for a batch of 3D tensors.
+
+    Args:
+        tensor (Tensor or ndarray): 4D tensor of shape [B, D, H, W].
+        axis (int): Axis within each volume to slice along.
+        pause (float): Time to wait between frames (in seconds).
+        colorscheme: Optional color scheme.
+        scale (int): Visual scaling factor.
+        legend (bool): Show slice index.
+        stride (int): Step size between slices.
+    """
+    np_array = tensor_to_numpy(tensor)
+
+    if np_array.ndim != 4:
+        raise ValueError("Tensor must be 4D [B, D, H, W]")
+
+    B = np_array.shape[0]
+    volumes = [np.moveaxis(np_array[b], axis, 0) for b in range(B)]
+    n_slices = volumes[0].shape[0]
+
+    console = Console()
+
+    grid_rows = int(math.floor(math.sqrt(B)))
+    grid_cols = int(math.ceil(B / grid_rows))
+
+    def get_render(idx):
+        rendered = []
+
+        for b in range(B):
+            slice_2d = volumes[b][idx]
+            scaled = np.repeat(np.repeat(slice_2d, scale, axis=1), scale, axis=0)
+            lines = _viz_2d(scaled, colorscheme, **kwargs)
+            rendered.append(lines)
+
+        max_height = max(len(r) for r in rendered)
+        for r in rendered:
+            while len(r) < max_height:
+                r.append("")
+
+        lines = []
+        for row in range(grid_rows):
+            line_blocks = []
+            for col in range(grid_cols):
+                idx_in_batch = row * grid_cols + col
+                if idx_in_batch < B:
+                    line_blocks.append(rendered[idx_in_batch])
+            for i in range(max_height):
+                lines.append("".join(block[i] for block in line_blocks if i < len(block)))
+
+        if legend:
+            lines.append(f"[italic]slice = {idx}/{n_slices - 1}[/]")
+
+        return "\n".join(lines)
+
+    with Live(console=console, screen=False, refresh_per_second=1 / pause) as live:
+        for idx in range(0, n_slices, stride):
+            live.update(get_render(idx))
+            time.sleep(pause)
+
+
+def viz_batch_volume_manual(tensor, axis=0, colorscheme: ColorScheme = None, scale=1, legend=True, stride=1, **kwargs):
+    """
+    Interactive viewer for a batch of 3D tensors.
+
+    Args:
+        tensor (Tensor or ndarray): 4D tensor of shape [B, D, H, W].
+        axis (int): Slice axis within each volume.
+        colorscheme: Optional color scheme.
+        scale (int): Visual scaling factor.
+        stride (int): Step size when navigating.
+    """
+    np_array = tensor_to_numpy(tensor) # TODO tensor
+
+    if np_array.ndim != 4:
+        raise ValueError("Tensor must be 4D [B, D, H, W]")
+
+    B = np_array.shape[0]
+    volumes = [np.moveaxis(np_array[b], axis, 0) for b in range(B)]
+    n_slices = volumes[0].shape[0]
+
+    idx = 0
+    console = Console()
+
+    grid_rows = int(math.floor(math.sqrt(B)))
+    grid_cols = int(math.ceil(B / grid_rows))
+
+    def get_render(idx):
+        rendered = []
+
+        for b in range(B):
+            slice_2d = volumes[b][idx]
+            scaled = np.repeat(np.repeat(slice_2d, scale, axis=1), scale, axis=0)
+            lines = _viz_2d(scaled, colorscheme, **kwargs)
+            rendered.append(lines)
+
+        # Pad all rendered blocks to same height
+        max_height = max(len(r) for r in rendered)
+        for r in rendered:
+            while len(r) < max_height:
+                r.append("")
+
+        # Arrange in grid
+        lines = []
+        for row in range(grid_rows):
+            line_blocks = []
+            for col in range(grid_cols):
+                idx_in_batch = row * grid_cols + col
+                if idx_in_batch < B:
+                    line_blocks.append(rendered[idx_in_batch])
+            for i in range(max_height):
+                lines.append("".join(block[i] for block in line_blocks if i < len(block)))
+
+        if legend:
+            lines.append(f"[italic]slice = {idx}/{n_slices - 1}[/]")
+            lines.append("[dim]\u25C4 a |q quit| d \u25BA[/]")
+
+        return "\n".join(lines)
+
+    with Live(get_render(idx), console=console, screen=False, auto_refresh=False) as live:
+        while True:
+            key = readchar.readkey()
+            new_idx = idx
+            if key == "q":
+                break
+            elif key in ("d", readchar.key.RIGHT):
+                new_idx = (idx + stride) % n_slices
+            elif key in ("a", readchar.key.LEFT):
+                new_idx = (idx - stride) % n_slices
+
+            if new_idx != idx:
+                idx = new_idx
+                live.update(get_render(idx), refresh=True)

--- a/tensorhue/viz.py
+++ b/tensorhue/viz.py
@@ -13,7 +13,6 @@ from tensorhue._print_opts import PRINT_OPTS
 from tensorhue.converters import tensor_to_numpy, mro_to_strings
 
 
-
 def viz(tensor, **kwargs):
     try:
         mro_strings = mro_to_strings(tensor.__class__.__mro__)
@@ -189,6 +188,7 @@ def get_terminal_size(default_width: int = 100, default_height: int = 70) -> os.
     else:
         return os.terminal_size((default_width, default_height))
 
+
 # Visualizing volumetric data (For MRI or videos)
 def viz_volume(tensor, axis=0, pause=0.1, colorscheme: ColorScheme = None, scale=1, legend=True, stride=1, **kwargs):
     """
@@ -204,7 +204,7 @@ def viz_volume(tensor, axis=0, pause=0.1, colorscheme: ColorScheme = None, scale
         **kwargs: Passed to color scheme.
     """
     np_array = tensor_to_numpy(tensor)
-    
+
     if np_array.ndim != 3:
         raise ValueError("Only 3D tensors can be passed to viz_volume")
 
@@ -217,8 +217,8 @@ def viz_volume(tensor, axis=0, pause=0.1, colorscheme: ColorScheme = None, scale
             scaled = np.repeat(np.repeat(slice_2d, scale, axis=1), scale, axis=0)
             lines = _viz_2d(scaled, colorscheme, **kwargs)
             if legend:
-               lines.append(f"[italic]slice = {i}/{n_slices - 1}, shape = {slice_2d.shape}[/]")
-               # lines.append(f"[italic]shape = {shape}[/]")
+                lines.append(f"[italic]slice = {i}/{n_slices - 1}, shape = {slice_2d.shape}[/]")
+                # lines.append(f"[italic]shape = {shape}[/]")
             live.update("\n".join(lines))
             time.sleep(pause)
 
@@ -267,7 +267,9 @@ def viz_volume_manual(tensor, axis=0, colorscheme: ColorScheme = None, scale=1, 
                 live.update(get_render(idx), refresh=True)
 
 
-def viz_batch_volume(tensor, axis=0, pause=0.1, colorscheme: ColorScheme = None, scale=1, legend=True, stride=1, **kwargs):
+def viz_batch_volume(
+    tensor, axis=0, pause=0.1, colorscheme: ColorScheme = None, scale=1, legend=True, stride=1, **kwargs
+):
     """
     Animated viewer for a batch of 3D tensors.
 
@@ -340,7 +342,7 @@ def viz_batch_volume_manual(tensor, axis=0, colorscheme: ColorScheme = None, sca
         scale (int): Visual scaling factor.
         stride (int): Step size when navigating.
     """
-    np_array = tensor_to_numpy(tensor) # TODO tensor
+    np_array = tensor_to_numpy(tensor)  # TODO tensor
 
     if np_array.ndim != 4:
         raise ValueError("Tensor must be 4D [B, D, H, W]")


### PR DESCRIPTION
## Description

More and more PyTorch users are working with 3D data, such as MRI/CT volumes, GIFs, or videos. TensorHue should allow users to visualize volumes in slices along a chosen axis. This PR adds functions to .viz that allow users to either:   

1. Automatically render slices of 3D tensors along a chosen axis   
2. Manually step through slices of 3D tensors along a chosen axis by using arrow keys or A+D. 

Both functionalities also get extended to batches of data, which is very convenient when quickly checking a dataset. Users can just load a batch of volumes (or 3 channel images) and render them channel by channel in a grid. The `stride` parameter also allows users to skip channels, should data be stacked along the channel dimension, or for a quicker overview in the case of MRI volumes (128, or even 256 channels are very common for brain MRI data.)

This PR fixes #15 .

## Checklist:

- [✓] PR is related to an existing issue - of none exist, open a new issue yourself
- [✓] PR includes the issue number that it fixes, e.g. "This PR fixes #000000."
- [✓] PR passes all automated checks (linting, tests) with a green checkmark
